### PR TITLE
modularized terraform bucket creation

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,32 +9,14 @@ terraform {
 
 provider "aws" {}
 
-resource "aws_s3_bucket" "bucket" {
-  bucket = "databricks-bucket-${var.environment}"
+module "public_bucket"{
+  source = "./modules/public_bucket_aws"
+  bucket_name = "databricks-dlt-demo"
 }
 
-resource "aws_s3_bucket_ownership_controls" "control" {
-  bucket = aws_s3_bucket.bucket.id
-  rule {
-    object_ownership = "BucketOwnerPreferred"
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "block" {
-  bucket = aws_s3_bucket.bucket.id
-
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
-}
-
-resource "aws_s3_bucket_acl" "bucket_acl" {
-  depends_on = [
-    aws_s3_bucket_ownership_controls.control,
-    aws_s3_bucket_public_access_block.block,
-  ]
-
-  bucket = aws_s3_bucket.bucket.id
+resource "aws_s3_object" "object" {
+  bucket = module.public_bucket.bucket_id
+  key    = "from_tf.json"
+  source = "../mock_data/workers2.json"
   acl    = "public-read"
 }

--- a/terraform/modules/public_bucket_aws/output.tf
+++ b/terraform/modules/public_bucket_aws/output.tf
@@ -1,0 +1,3 @@
+output "bucket_id" {
+  value = aws_s3_bucket.bucket.id
+}

--- a/terraform/modules/public_bucket_aws/public_bucket_aws.tf
+++ b/terraform/modules/public_bucket_aws/public_bucket_aws.tf
@@ -1,0 +1,29 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = "${var.bucket_name}-${var.environment}"
+}
+
+resource "aws_s3_bucket_ownership_controls" "control" {
+  bucket = aws_s3_bucket.bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "block" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  depends_on = [
+    aws_s3_bucket_ownership_controls.control,
+    aws_s3_bucket_public_access_block.block,
+  ]
+
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "public-read"
+}

--- a/terraform/modules/public_bucket_aws/variables.tf
+++ b/terraform/modules/public_bucket_aws/variables.tf
@@ -1,0 +1,10 @@
+variable "environment" {
+  description = "The environment to deploy the bucket in."
+  type = string
+  default = "dev"
+}
+
+variable "bucket_name" {
+  description = "The name of the bucket"
+  type = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,0 @@
-variable "environment" {
-  type = string
-  default = "dev"
-}


### PR DESCRIPTION
Closes #4 
Modularized terraform bucket creation. Buckets created with the public_bucket_aws module will be publicly accessible.